### PR TITLE
adding minvalue to metrics dict

### DIFF
--- a/network_metrics.py
+++ b/network_metrics.py
@@ -196,7 +196,7 @@ def run_all_metrics(people,network):
 
     return metric_values,[metric.__name__.split('run_')[1] for metric in metrics]
 
-def run_weighted_metrics(people_list, network_list, metrics, combine_metric_method='multiply', minvalue = 0.01):
+def run_weighted_metrics(people_list, network_list, metrics, combine_metric_method='multiply', minvalue=0.01):
     '''
     metrics is a list of dict's with each dict containing the following keys.
         function : the name of the metric function (e.g., run_frac_mentees_with_a_mentor)
@@ -207,6 +207,7 @@ def run_weighted_metrics(people_list, network_list, metrics, combine_metric_meth
             binary : non-zero numbers are converted to 1 (and given preference)
             binary0: zeros are converted to 1 (and given preference); all other numbers are converted to zero
         normalize : boolean, if True then the metric values are normalized to [0,1].  This step is performed before weighting
+        minvalue : float value that sets the minimum value for that metric (optional, = 0.01 by default as defined in the function args).
 
     combine_metric_method can be either 'multiply' or 'mean', see code for both methods ('multiply is the default')
 
@@ -249,13 +250,16 @@ def run_weighted_metrics(people_list, network_list, metrics, combine_metric_meth
         if ('weight' not in m):
             m['weight'] = 1
 
+        if ('minvalue' not in m):
+            m['minvalue'] = minvalue
+
         if ('type' in m):
             if (m['type'] == 'maximize'):
-                weighted_metric_values[i,:] = np.where(weighted_metric_values[i,:] > 0, weighted_metric_values[i,:], minvalue)
+                weighted_metric_values[i,:] = np.where(weighted_metric_values[i,:] > 0, weighted_metric_values[i,:], m['minvalue'])
                 weighted_metric_values[i,:] = m['weight']*weighted_metric_values[i,:]
             elif (m['type'] == 'minimize'):
                 weighted_metric_values[i,:] = (1. - weighted_metric_values[i,:])
-                weighted_metric_values[i,:] = np.where(weighted_metric_values[i,:] > 0, weighted_metric_values[i,:], minvalue)
+                weighted_metric_values[i,:] = np.where(weighted_metric_values[i,:] > 0, weighted_metric_values[i,:], m['minvalue'])
                 weighted_metric_values[i,:] = m['weight']*weighted_metric_values[i,:]
             elif (m['type'] == 'binary'):
                 weighted_metric_values[i,:] = weighted_metric_values[i,:] > 0


### PR DESCRIPTION
This will allow the user to set the minimum value for each individual metric.  It may be the case that we really do want some metrics to have a minimum value of zero (and therefore throw out those networks).